### PR TITLE
Handle content-type header with charset correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -806,7 +806,7 @@
     "eslint-plugin-es": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
-      "integrity": "sha1-R19luyDJk/wQ6Mj+d9HWAGgHLaY=",
+      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
       "dev": true,
       "requires": {
         "eslint-utils": "^1.3.0",

--- a/src/validators/ResponseValidator.js
+++ b/src/validators/ResponseValidator.js
@@ -17,7 +17,8 @@ function responseValidator(response, data) {
         if (bodySchema.validate) {
             validator = bodySchema;
         } else {
-            const responseContentType = data.headers['Content-Type'] || data.headers['content-type'] || DEFAULT_CONTENT_TYPE;
+            const responseContentTypeHeader = data.headers['Content-Type'] || data.headers['content-type'] || DEFAULT_CONTENT_TYPE;
+            const responseContentType = responseContentTypeHeader.split(';')[0]; // This is to filter out things like charset
             validator = bodySchema[responseContentType];
             if (!validator) {
                 this.errors = [{ message: `No schema defined for response content-type "${responseContentType}"` }

--- a/src/validators/ResponseValidator.js
+++ b/src/validators/ResponseValidator.js
@@ -18,7 +18,7 @@ function responseValidator(response, data) {
             validator = bodySchema;
         } else {
             const responseContentTypeHeader = data.headers['Content-Type'] || data.headers['content-type'] || DEFAULT_CONTENT_TYPE;
-            const responseContentType = responseContentTypeHeader.split(';')[0]; // This is to filter out things like charset
+            const responseContentType = responseContentTypeHeader.split(';')[0].trim(); // This is to filter out things like charset
             validator = bodySchema[responseContentType];
             if (!validator) {
                 this.errors = [{ message: `No schema defined for response content-type "${responseContentType}"` }

--- a/test/openapi3/response/response-oai3-tests.js
+++ b/test/openapi3/response/response-oai3-tests.js
@@ -66,6 +66,18 @@ describe('oai3 - response tests', function () {
                 expect(schemaEndpoint.errors).to.be.equal(null);
                 expect(isMatch).to.be.true;
             });
+            it('resolves content type for content-type with charset', function () {
+                let schemaEndpoint = schema['/dog']['post'].responses['201'];
+                let isMatch = schemaEndpoint.validate({ body:
+                        {
+                            'bark': 'hav hav'
+                        },
+                headers: {
+                    'content-type': 'application/json; charset=utf-8'
+                } });
+                expect(schemaEndpoint.errors).to.be.equal(null);
+                expect(isMatch).to.be.true;
+            });
             it('throws an error for undefined content type correctly', function () {
                 let schemaEndpoint = schema['/dog']['post'].responses['201'];
                 let isMatch = schemaEndpoint.validate({ body:


### PR DESCRIPTION
We've hit another edge case where service was setting content-type with charset, and this was breaking validation.