### PR TITLE
update readme description of ajvConfigParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Options currently supports:.
 If the element is an object, it must include `name` and `definition`. If the element is a function, it should accept `ajv` as its first argument and inside the function you need to call `ajv.addKeyword` to add your custom keyword 
 - `makeOptionalAttributesNullable` - Boolean that forces preprocessing of Swagger schema to include 'null' as possible type for all non-required properties. Main use-case for this is to ensure correct handling of null values when Ajv type coercion is enabled
 - `ajvConfigBody` - Object that will be passed as config to new Ajv instance which will be used for validating request body. Can be useful to e. g. enable type coercion (to automatically convert strings to numbers etc). See Ajv documentation for supported values.
-- `ajvConfigParams` - Object that will be passed as config to new Ajv instance which will be used for validating request body. See Ajv documentation for supported values.
+- `ajvConfigParams` - Object that will be passed as config to new Ajv instance which will be used for validating request headers and parameters. See Ajv documentation for supported values.
 - `contentTypeValidation` - Boolean that indicates if to perform content type validation in case `consume` field is specified and the request body is not empty.
 - `expectFormFieldsInBody` - Boolean that indicates whether form fields of non-file type that are specified in the schema should be validated against request body (e. g. Multer is copying text form fields to body)
 - `buildRequests` - Boolean that indicates whether if create validators for requests, default is true.


### PR DESCRIPTION
I was confused about the difference between ```ajvConfigBody``` and ```ajvConfigParams```, and it appeared there was a copy and paste error in the readme, so I've updated it to say the ```ajvConfigParams``` is used for header and parameter validation.