### PR TITLE
Allow body validator to be created where possible

### DIFF
--- a/src/parsers/open-api3.js
+++ b/src/parsers/open-api3.js
@@ -86,7 +86,14 @@ function handleBodyValidation(
     validationType,
     { ajvConfigBody, formats, keywords }
 ) {
-    if (!dereferencedBodySchema || !referencedBodySchema) return;
+
+    if (!dereferencedBodySchema) {
+        return
+    }
+
+    if (dereferencedBodySchema.discriminator && !referencedBodySchema) {
+        return
+    }
 
     const defaultAjvOptions = {
         allErrors: true

--- a/test/openapi3/general/external-ref/file-refs-paths-users.yaml
+++ b/test/openapi3/general/external-ref/file-refs-paths-users.yaml
@@ -1,0 +1,20 @@
+paths:
+  users:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: "./file-refs-user.yaml#/components/schemas/User"
+                - $ref: "./file-refs-permissions.json#/components/schemas/Permissions"
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "./file-refs-user.yaml#/components/schemas/User"
+                  - $ref: "./file-refs-permissions.json#/components/schemas/Permissions"

--- a/test/openapi3/general/external-ref/file-refs-paths.test.js
+++ b/test/openapi3/general/external-ref/file-refs-paths.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const chai = require('chai').use(require('chai-as-promised'));
+const path = require('path');
+const fs = require('fs');
+const jsyaml = require('js-yaml');
+const { expect } = chai;
+
+const schemaValidatorGenerator = require('../../../../src');
+
+describe('Loading definitions file with file refs', () => {
+    describe('calling buildSchemaSync with path to definitions file', () => {
+        const swaggerPath = path.join(__dirname, 'file-refs-paths.yaml');
+        const schema = schemaValidatorGenerator.buildSchemaSync(swaggerPath, {});
+        const validator = schema['/users'].post.body['application/json'];
+
+        it('should validate according to yaml file schema', () => {
+
+            validator.validate({
+                id: 'dsadasda',
+                permissions: []
+            });
+            expect(validator.errors).to.eql([
+                {
+                    keyword: 'required',
+                    dataPath: '',
+                    schemaPath: '#/allOf/0/required',
+                    params: { missingProperty: 'email' },
+                    message: 'should have required property \'email\''
+                },
+                {
+                    keyword: 'required',
+                    dataPath: '',
+                    schemaPath: '#/allOf/0/required',
+                    params: { missingProperty: 'password' },
+                    message: 'should have required property \'password\''
+                },
+                {
+                    keyword: 'required',
+                    dataPath: '',
+                    schemaPath: '#/allOf/0/required',
+                    params: { missingProperty: 'name' },
+                    message: 'should have required property \'name\''
+                },
+                {
+                    dataPath: '',
+                    keyword: 'type',
+                    message: 'should be array',
+                    params: {
+                        type: 'array'
+                    },
+                    schemaPath: '#/allOf/1/type'
+                }
+            ]);
+        });
+
+    });
+
+});

--- a/test/openapi3/general/external-ref/file-refs-paths.yaml
+++ b/test/openapi3/general/external-ref/file-refs-paths.yaml
@@ -1,0 +1,7 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Users
+paths:
+  /users:
+    $ref: "./file-refs-paths-users.yaml#/paths/users"


### PR DESCRIPTION
The body validator was not getting created because the reference schema
does not contain the requestPath which in turn is because the way
external file is split (it moves all path of user to a separate file).

As referencedBodySchema is not needed to create the validator that is
needed I have relaxed the guard statement in handleBodyValidation().